### PR TITLE
Nav accessibility

### DIFF
--- a/_sass/_global.scss
+++ b/_sass/_global.scss
@@ -29,7 +29,7 @@ html {
 
     a:focus {
       box-shadow: none;
-      outline: 2px dotted #aeb0b5;
+      outline: 2px dotted $color-gray-light;
       outline-offset: 3px;
     }
 

--- a/_sass/_global.scss
+++ b/_sass/_global.scss
@@ -29,6 +29,8 @@ html {
 
     a:focus {
       box-shadow: none;
+      outline: 2px dotted #aeb0b5;
+      outline-offset: 3px;
     }
 
     h3 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code.gov/code-gov-style",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Style for code.gov including buttons, banners, and cards. Inspired by and somewhat based on USWDS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add an outline to links when they have focus.

BEFORE
<img width="481" alt="screen shot 2018-09-20 at 12 57 27 pm" src="https://user-images.githubusercontent.com/2197515/45834466-36e78a80-bcd5-11e8-86fe-23e21f0375cc.png">


AFTER
<img width="536" alt="screen shot 2018-09-20 at 12 56 54 pm" src="https://user-images.githubusercontent.com/2197515/45834487-41098900-bcd5-11e8-9b57-16e817be776e.png">
