### PR TITLE
fixed issue #8, width of quality tags

### DIFF
--- a/_sass/_cards.scss
+++ b/_sass/_cards.scss
@@ -25,12 +25,12 @@
     left: auto;
     right: 0;
     top: 0;
-    width: 3.75em;
+    width: 4.5em;
     height: 3.75em;
 
     &.high {
       background-color: #33CC66;
-      background: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%22500%22%20width%3D%22500%22%3E%0A%20%20%3Cpolygon%20points%3D%220%2C0%20500%2C0%20500%2C500%200%2C0%22%20fill%3D%22%2333CC66%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
+      background: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%22500%22%20width%3D%22700%22%3E%0A%20%20%3Cpolygon%20points%3D%220%2C0%20700%2C0%20700%2C500%200%2C0%22%20fill%3D%22%2333CC66%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
       @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
         background: url("/code-gov-style/assets/img/corner-tags/high.svg")
       }
@@ -38,7 +38,7 @@
 
     &.medium {
       background-color: #FF9933;
-      background: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%22500%22%20width%3D%22500%22%3E%0A%20%20%3Cpolygon%20points%3D%220%2C0%20500%2C0%20500%2C500%200%2C0%22%20fill%3D%22%23FF9933%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
+      background: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%22500%22%20width%3D%22700%22%3E%0A%20%20%3Cpolygon%20points%3D%220%2C0%20700%2C0%20700%2C500%200%2C0%22%20fill%3D%22%23FF9933%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
       @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
         background: url("/code-gov-style/assets/img/corner-tags/medium.svg")
       }
@@ -46,7 +46,7 @@
 
     &.low {
       background-color: #F00;
-      background: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%22500%22%20width%3D%22500%22%3E%0A%20%20%3Cpolygon%20points%3D%220%2C0%20500%2C0%20500%2C500%200%2C0%22%20fill%3D%22%23F00%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
+      background: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%22500%22%20width%3D%22700%22%3E%0A%20%20%3Cpolygon%20points%3D%220%2C0%20700%2C0%20700%2C500%200%2C0%22%20fill%3D%22%23F00%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
       @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
         background: url("/code-gov-style/assets/img/corner-tags/low.svg")
       }

--- a/assets/img/corner-tags/high.svg
+++ b/assets/img/corner-tags/high.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="500" width="500">
-  <polygon points="0,0 500,0 500,500 0,0" fill="#33CC66"></polygon>
+<svg xmlns="http://www.w3.org/2000/svg" height="500" width="700">
+  <polygon points="0,0 700,0 700,500 0,0" fill="#33CC66"></polygon>
 </svg>

--- a/assets/img/corner-tags/low.svg
+++ b/assets/img/corner-tags/low.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="500" width="500">
-  <polygon points="0,0 500,0 500,500 0,0" fill="#F00"></polygon>
+<svg xmlns="http://www.w3.org/2000/svg" height="500" width="700">
+  <polygon points="0,0 700,0 700,500 0,0" fill="#F00"></polygon>
 </svg>

--- a/assets/img/corner-tags/medium.svg
+++ b/assets/img/corner-tags/medium.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="500" width="500">
-  <polygon points="0,0 500,0 500,500 0,0" fill="#FF9933"></polygon>
+<svg xmlns="http://www.w3.org/2000/svg" height="500" width="700">
+  <polygon points="0,0 700,0 700,500 0,0" fill="#FF9933"></polygon>
 </svg>


### PR DESCRIPTION
- Increases width for corner tag
- Increase width in SVG files (which are used by IE) and inline SVGs (which are used by modern browsers and created using encodeURIComponent on the SVG files)

Before:
![image](https://user-images.githubusercontent.com/4313463/50138847-ecdb5a00-026d-11e9-91d0-6c98d8886226.png)


After:
![image](https://user-images.githubusercontent.com/4313463/50138829-de8d3e00-026d-11e9-8138-8423c2657ec0.png)

Fixes https://github.com/GSA/code-gov-front-end/issues/8