### PR TITLE
Add more padding around blockquotes

### DIFF
--- a/_sass/_quotes.scss
+++ b/_sass/_quotes.scss
@@ -43,7 +43,7 @@ blockquote {
       color: $brand-teal;
       content: '“';
       font-size: 1.75em;
-      left: -2.5rem;
+      left: -4.5rem;
       padding-right: 0.5rem;
       position: absolute;
       top: -1.5rem;
@@ -59,7 +59,7 @@ blockquote {
       content: '”';
       font-size: 1.75em;
       line-height: 0.6;
-      padding-left: 0.5rem;
+      padding-left: 1.5rem;
       position: absolute;
       vertical-align: text-top;
 


### PR DESCRIPTION
**Summary**

On the code.gov homepage, I noticed this

![image (8)](https://user-images.githubusercontent.com/1680080/58272765-366c2b80-7d5d-11e9-9d39-c43eeb4994f1.png)

**Test plan (required)**

I have not tested this locally, but I did tweak these values in the browser's devtools and now it looks like this:

![Screen Shot 2019-05-23 at 1 19 10 PM](https://user-images.githubusercontent.com/1680080/58272838-61ef1600-7d5d-11e9-947a-0c354be3951d.png)


## Note: I am not very familiar with this project, so I have no idea where or how else this style gets used. It may break something somewhere else.