### PR TITLE
Fix Pa11y Testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.4-node-browsers
+      - image: circleci/ruby:2.5.5-node-browsers
 
     working_directory: ~/code-gov-style
 
@@ -28,11 +28,10 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      # run linting!
-      - run: npm run lint
-      - run: gem install bundler
-      - run: bundle install
-      - run: npm run serve & sleep 5; npm run test-pa11y
+      - run: npm run lint # run linting!
+      - run: gem install bundler # install bundler
+      - run: bundle install # install needed ruby gems
+      - run: npm run serve & sleep 5; npm run test-pa11y # run server in background, then run accessibility testing
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       # run linting!
       - run: npm run lint
       - run: gem install bundler
+      - run: bundle install
       - run: npm run serve & sleep 5; npm run test-pa11y
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.4-node
+      - image: circleci/ruby:2.4-node-browsers
 
     working_directory: ~/code-gov-style
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.12
+      - image: circleci/ruby:2.4-node
 
     working_directory: ~/code-gov-style
 
@@ -30,8 +30,9 @@ jobs:
 
       # run linting!
       - run: npm run lint
-      - run: npm run test-pa11y
-      
+      - run: gem install bundler
+      - run: npm run serve & sleep 5; npm run test-pa11y
+
 workflows:
   version: 2
   commit:

--- a/components/autocomplete.md
+++ b/components/autocomplete.md
@@ -9,7 +9,7 @@ title: "Autocomplete"
 <div class="banner large">
   <div class="banner-content">
     <div style="margin: 0 auto; position: relative; width: 400px;">
-      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%" aria-label="search">
+      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%">
       <ul class="autocomplete">
         <li>
           <a>
@@ -37,7 +37,7 @@ title: "Autocomplete"
 <div class="banner">
   <div class="banner-content">
     <div style="margin: 0 auto; width: 400px;">
-      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%" aria-label="search">
+      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%">
       <ul class="autocomplete">
         <li>
           <a>

--- a/components/autocomplete.md
+++ b/components/autocomplete.md
@@ -9,7 +9,7 @@ title: "Autocomplete"
 <div class="banner large">
   <div class="banner-content">
     <div style="margin: 0 auto; position: relative; width: 400px;">
-      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%">
+      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%" aria-label="search">
       <ul class="autocomplete">
         <li>
           <a>
@@ -37,7 +37,7 @@ title: "Autocomplete"
 <div class="banner">
   <div class="banner-content">
     <div style="margin: 0 auto; width: 400px;">
-      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%">
+      <input placeholder="Search Thousands of Projects..." type="search" style="width: 100%" aria-label="search">
       <ul class="autocomplete">
         <li>
           <a>


### PR DESCRIPTION
## Summary
This PR fixes/implements the following **bugs/features**:
* [ ] change CircleCI config to run pa11y testing on PR pushes; the testing was previously not running in the CI environment

## Motivation
- https://trello.com/c/qt0ROzmB/1501-fix-the-accessibility-testing-not-running-on-the-code-gov-style-repo

![image](https://user-images.githubusercontent.com/5049650/59638314-acc23a80-911d-11e9-8929-7229f922ed5a.png)

## Test plan (required)
We know this code works because the accessibility tests are now being run on PR pushes.  The CircleCI build shows up as [passing](https://circleci.com/gh/GSA/code-gov-style/60) when errors are NOT present and [failing](https://circleci.com/gh/GSA/code-gov-style/59) when errors are present.