### PR TITLE
Fix references to Source Sans so that it shows up as expected

### DIFF
--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -14,7 +14,7 @@ button {
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+  font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
   font-size: 1.7rem;
   font-weight: normal;
   line-height: 1;

--- a/_sass/_global.scss
+++ b/_sass/_global.scss
@@ -1,13 +1,13 @@
 html {
   box-sizing: border-box;
-  font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+  font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
   font-size: 10px;
   line-height: 1.15;
 
   body {
     background-color: $color-white;
     box-sizing: border-box;
-    font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+    font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
     font-feature-settings: "kern", "liga", "pnum";
     font-size: 14px;
     line-height: 1.42857143;

--- a/_sass/_sidebars.scss
+++ b/_sass/_sidebars.scss
@@ -33,7 +33,7 @@
     border: none;
     color: $color-black-light;
     display: block;
-    font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+    font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
     font-size: 0.95em;
     line-height: 1.3;
     padding: 0.85rem 1rem 0.85rem 1.5rem;


### PR DESCRIPTION
**Summary**

The `@font-face` code that is pulling in the Source Sans webfonts is naming them "Source Sans Pro Web", but the current Sass in this repo is (most of the time) looking for just "Source Sans Pro" (_sans_ "Web"), resulting in Helvetica being rendered.

This PR fixes those Sass references so that Source Sans renders as expected.

**Test plan**

1. Pull this branch
1. `npm install && npm link`
1. Change to code-gov-front-end repo
1. `npm link @code.gov/code-gov-style`
1. `npm start`
1. View http://localhost:8080/ and see Source Sans in most places, rather than Helvetica.

| Before | After |
| ----- | ----- |
| ![Screenshot showing text in Helvetica](https://user-images.githubusercontent.com/1044670/60735462-6fcdb480-9f21-11e9-818d-8a82bef6b575.png) | ![Screenshot showing text in Source Sans](https://user-images.githubusercontent.com/1044670/60735479-807e2a80-9f21-11e9-9bbf-f6fefd4216ad.png) |

Happy belated Independence Day! 💪 🖥 🇺🇸 