### PR TITLE
fix: text wrapping for 2-line filters

### DIFF
--- a/_sass/_filter.scss
+++ b/_sass/_filter.scss
@@ -72,8 +72,9 @@ filter-box {
         margin-top: 15px;
 
         label {
+          display: inline-block;
+
           span {
-            display: inline-block;
             padding-right: 1.75rem;
           }
         }


### PR DESCRIPTION
# Resolves issue [#319](https://github.com/GSA/code-gov-front-end/issues/319)

**Summary**

This PR fixes a bug found in Chrome where when the content of a list item in the filter box wrapped onto another line, it was partially hidden by the checkbox.

**Screenshot of issue**

<img width="232" alt="before" src="https://user-images.githubusercontent.com/12678977/68079140-f359be00-fdba-11e9-906e-5969a5150c9c.png">

**Test plan (required)**

To test this PR locally, sync the `code-gov-styles` repo with the `code-gov-front-end` repo.
In `code-gov-front-end` run `npm run start` to start the server.
Open the Chrome web browser and go to http://localhost:8080/browse-projects?&page=1&size=10&sort=data_quality
Review the filter list styles and verify that list items which span more than one line of content flow to the right of the checkbox and not behind it.

** Screenshot of expected results**

<img width="234" alt="after" src="https://user-images.githubusercontent.com/12678977/68079236-2d2bc400-fdbd-11e9-9680-b444b588ff61.png">

**Closing issues**

Closes #319
